### PR TITLE
Create Pause Command

### DIFF
--- a/hardcore-twitch-integration.iml
+++ b/hardcore-twitch-integration.iml
@@ -26,6 +26,11 @@
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.4.10" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:okhttp:4.9.1" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.4.10" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Maven: org.java-websocket:Java-WebSocket:1.5.1" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT" level="project" />

--- a/hardcore-twitch-integration.iml
+++ b/hardcore-twitch-integration.iml
@@ -4,7 +4,7 @@
     <facet type="minecraft" name="Minecraft">
       <configuration>
         <autoDetectTypes>
-          <platformType>BUKKIT</platformType>
+          <platformType>PAPER</platformType>
         </autoDetectTypes>
       </configuration>
     </facet>
@@ -21,6 +21,11 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:okhttp:4.9.1" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.4.10" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Maven: org.java-websocket:Java-WebSocket:1.5.1" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT" level="project" />
@@ -37,5 +42,10 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-tree:9.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-analysis:9.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.6" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:okhttp:4.9.1" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.4.10" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -91,5 +91,10 @@
       <version>2.8.6</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>4.9.1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/HardcoreTwitchIntegration.java
+++ b/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/HardcoreTwitchIntegration.java
@@ -4,11 +4,14 @@ import com.github.sh0ckr6.hardcoretwitchintegration.beans.ChannelPointRedemption
 import com.github.sh0ckr6.hardcoretwitchintegration.beans.CheerEventBean;
 import com.github.sh0ckr6.hardcoretwitchintegration.beans.EventSubNotificationBean;
 import com.github.sh0ckr6.hardcoretwitchintegration.beans.SubscriptionEventBean;
+import com.github.sh0ckr6.hardcoretwitchintegration.commands.PauseCommand;
 import com.github.sh0ckr6.hardcoretwitchintegration.commands.SubscribeCommand;
+import com.github.sh0ckr6.hardcoretwitchintegration.commands.UnpauseCommand;
 import com.github.sh0ckr6.hardcoretwitchintegration.gift.Gift;
 import com.github.sh0ckr6.hardcoretwitchintegration.listeners.MainListener;
 import com.github.sh0ckr6.hardcoretwitchintegration.managers.ConfigManager;
 import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
 import org.bukkit.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -34,12 +37,13 @@ public final class HardcoreTwitchIntegration extends JavaPlugin {
   public boolean isPreventedFromBreaking;
   public boolean isPreventedFromInteracting;
   public List<Gift<?>> gifts = new ArrayList<>();
-  
-  private ConfigManager configManager;
+  public ConfigManager configManager;
+  public OkHttpClient okHttpClient;
   
   @Override
   public void onEnable() {
     // Plugin startup logic
+    okHttpClient = new OkHttpClient();
     getLogger().log(Level.INFO, "Successfully opened HardcoreTwitchIntegration");
     attemptWebSocketConnection();
     player = Bukkit.getOnlinePlayers().stream().filter(p -> p.getName().equalsIgnoreCase("sh0ckR6")).findFirst().get();
@@ -182,15 +186,17 @@ public final class HardcoreTwitchIntegration extends JavaPlugin {
   
   private void registerCommands() {
     new SubscribeCommand(this);
+    new PauseCommand(this);
+    new UnpauseCommand(this);
   }
   
   private void registerConfigs() {
     configManager = new ConfigManager(this);
+    configManager.createConfig("config");
   }
   
   @Override
   public void onDisable() {
-    // Plugin shutdown logic
   }
   
   @Override

--- a/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/beans/ChannelPointRewardGetBean.java
+++ b/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/beans/ChannelPointRewardGetBean.java
@@ -1,0 +1,39 @@
+package com.github.sh0ckr6.hardcoretwitchintegration.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChannelPointRewardGetBean {
+  public List<ChannelPointRewardBean> data = new ArrayList<>();
+  
+  @Override
+  public String toString() {
+    return "ChannelPointRewardGetBean{" +
+           "data=" + data +
+           '}';
+  }
+  public static class ChannelPointRewardBean {
+    public String id;
+    public String title;
+    public String prompt;
+    public int cost;
+    public String background_color;
+    public boolean is_enabled;
+    public boolean is_user_input_required;
+    public boolean is_paused;
+  
+    @Override
+    public String toString() {
+      return "ChannelPointRewardBean{" +
+             "id='" + id + '\'' +
+             ", title='" + title + '\'' +
+             ", prompt='" + prompt + '\'' +
+             ", cost=" + cost +
+             ", background_color='" + background_color + '\'' +
+             ", is_enabled=" + is_enabled +
+             ", is_user_input_required=" + is_user_input_required +
+             ", is_paused=" + is_paused +
+             '}';
+    }
+  }
+}

--- a/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/commands/PauseCommand.java
+++ b/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/commands/PauseCommand.java
@@ -1,0 +1,84 @@
+package com.github.sh0ckr6.hardcoretwitchintegration.commands;
+
+import com.github.sh0ckr6.hardcoretwitchintegration.HardcoreTwitchIntegration;
+import com.github.sh0ckr6.hardcoretwitchintegration.beans.ChannelPointRewardGetBean;
+import com.google.gson.Gson;
+import okhttp3.*;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public class PauseCommand implements CommandExecutor {
+  
+  HardcoreTwitchIntegration plugin;
+  
+  public PauseCommand(HardcoreTwitchIntegration plugin) {
+    this.plugin = plugin;
+    plugin.getCommand("pause").setExecutor(this);
+  }
+  
+  @Override
+  public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    if (plugin.configManager.getConfig("config") == null) {
+      plugin.getLogger().severe("config.yml was not found! Creating...");
+      plugin.configManager.createConfig("config");
+      return true;
+    }
+    FileConfiguration config = plugin.configManager.getConfig("config");
+    final String apiKey = config.getString("twitch-token");
+    
+    Request channelPointRequest = new Request.Builder()
+            .url("https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=188494816&only_manageable_rewards=true")
+            .addHeader("client-id", "0pxgd0l3lwfy3xxcom1slhmqjlz6ww")
+            .addHeader("Authorization", "Bearer " + apiKey)
+            .get()
+            .build();
+    
+    plugin.okHttpClient.newCall(channelPointRequest).enqueue(new PauseCallback());
+  
+    return false;
+  }
+  
+  private class PauseCallback implements Callback {
+    @Override
+    public void onFailure(@NotNull Call call, @NotNull IOException e) {
+      plugin.getLogger().severe("Failed to contact Twitch API to receive list of channel points");
+      e.printStackTrace();
+    }
+  
+    @Override
+    public void onResponse(@NotNull Call call, @NotNull Response response) {
+      RequestBody pauseBody = new FormBody.Builder()
+              .add("is_paused", "true")
+              .build();
+  
+      FileConfiguration config = plugin.configManager.getConfig("config");
+      final String apiKey = config.getString("twitch-token");
+      
+      Gson gson = new Gson();
+      final ChannelPointRewardGetBean rewardGetBean = gson.fromJson(response.body().charStream(), ChannelPointRewardGetBean.class);
+      rewardGetBean.data.forEach(reward -> {
+        Request channelPointPatchRequest = new Request.Builder()
+                .url("https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=188494816&id=" + reward.id)
+                .addHeader("client-id", "0pxgd0l3lwfy3xxcom1slhmqjlz6ww")
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .patch(pauseBody)
+                .build();
+        try {
+          plugin.okHttpClient.newCall(channelPointPatchRequest).execute();
+        } catch (IOException e) {
+          e.printStackTrace();
+        } finally {
+          response.body().close();
+        }
+      });
+      plugin.player.sendMessage(ChatColor.GREEN + "All rewards are now " + ChatColor.GOLD + "paused.");
+    }
+  }
+}

--- a/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/commands/UnpauseCommand.java
+++ b/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/commands/UnpauseCommand.java
@@ -1,0 +1,84 @@
+package com.github.sh0ckr6.hardcoretwitchintegration.commands;
+
+import com.github.sh0ckr6.hardcoretwitchintegration.HardcoreTwitchIntegration;
+import com.github.sh0ckr6.hardcoretwitchintegration.beans.ChannelPointRewardGetBean;
+import com.google.gson.Gson;
+import okhttp3.*;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public class UnpauseCommand implements CommandExecutor {
+  
+  HardcoreTwitchIntegration plugin;
+  
+  public UnpauseCommand(HardcoreTwitchIntegration plugin) {
+    this.plugin = plugin;
+    plugin.getCommand("unpause").setExecutor(this);
+  }
+  
+  @Override
+  public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    if (plugin.configManager.getConfig("config") == null) {
+      plugin.getLogger().severe("config.yml was not found! Creating...");
+      plugin.configManager.createConfig("config");
+      return true;
+    }
+    FileConfiguration config = plugin.configManager.getConfig("config");
+    final String apiKey = config.getString("twitch-token");
+    
+    Request channelPointRequest = new Request.Builder()
+            .url("https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=188494816&only_manageable_rewards=true")
+            .addHeader("client-id", "0pxgd0l3lwfy3xxcom1slhmqjlz6ww")
+            .addHeader("Authorization", "Bearer " + apiKey)
+            .get()
+            .build();
+    
+    plugin.okHttpClient.newCall(channelPointRequest).enqueue(new UnpauseCallback());
+    
+    return false;
+  }
+  
+  private class UnpauseCallback implements Callback {
+    @Override
+    public void onFailure(@NotNull Call call, @NotNull IOException e) {
+      plugin.getLogger().severe("Failed to contact Twitch API to receive list of channel points");
+      e.printStackTrace();
+    }
+    
+    @Override
+    public void onResponse(@NotNull Call call, @NotNull Response response) {
+      RequestBody unpauseBody = new FormBody.Builder()
+              .add("is_paused", "false")
+              .build();
+      
+      FileConfiguration config = plugin.configManager.getConfig("config");
+      final String apiKey = config.getString("twitch-token");
+      
+      Gson gson = new Gson();
+      final ChannelPointRewardGetBean rewardGetBean = gson.fromJson(response.body().charStream(), ChannelPointRewardGetBean.class);
+      rewardGetBean.data.forEach(reward -> {
+        Request channelPointPatchRequest = new Request.Builder()
+                .url("https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=188494816&id=" + reward.id)
+                .addHeader("client-id", "0pxgd0l3lwfy3xxcom1slhmqjlz6ww")
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .patch(unpauseBody)
+                .build();
+        try {
+          plugin.okHttpClient.newCall(channelPointPatchRequest).execute();
+        } catch (IOException e) {
+          e.printStackTrace();
+        } finally {
+          response.body().close();
+        }
+      });
+      plugin.player.sendMessage(ChatColor.GREEN + "All rewards are now " + ChatColor.GOLD + "unpaused. " + ChatColor.RED + "Good luck...");
+    }
+  }
+}

--- a/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/managers/ConfigManager.java
+++ b/src/main/java/com/github/sh0ckr6/hardcoretwitchintegration/managers/ConfigManager.java
@@ -42,11 +42,11 @@ public class ConfigManager {
   }
   
   public FileConfiguration getConfig(String name) {
-    if (configurationFileMap.keySet().stream().noneMatch(config -> config.getName().equalsIgnoreCase(name))) return null;
-    return configurationFileMap.keySet().stream()
-            .filter(config -> config.getName().equalsIgnoreCase(name))
+    if (configurationFileMap.values().stream().noneMatch(file -> file.getName().equalsIgnoreCase(name + ".yml"))) return null;
+    return YamlConfiguration.loadConfiguration(configurationFileMap.values().stream()
+            .filter(file -> file.getName().equalsIgnoreCase(name + ".yml"))
             .findFirst()
-            .get();
+            .get());
   }
   
   public void saveConfig(FileConfiguration config) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,3 +11,7 @@ commands:
     description: send a message to the websocket server
   resub:
     description: send a resub message
+  pause:
+    description: pause all redemptions
+  unpause:
+    description: unpause all redemptions


### PR DESCRIPTION
# Create Pause Command
## Overview
This pull request adds a `/pause` and `/unpause` command to handle management of channel point requests.

## Features
### [Feature/Channel Points] Add `/pause` and `/unpause` command
*For when you just need to take a break...*

Adds `/pause` command to help with management of channel point rewards from Minecraft.
- Pauses all channel point requests that the plugin can manage. 
   - Automatic generation of channel point rewards will be implemented in a future pull request. As of right now, all channel point rewards that can be managed by the plugin must be manually added by using the Twitch API.

Adds `/unpause` command to help with management of channel point rewards from Minecraft.
- Pauses all channel point requests that the plugin can manage.
  - Automatic generation of channel point rewards will be implemented in a future pull request. As of right now, all channel point rewards that can be managed by the plugin must be manually added by using the Twitch API.

## Linked Issues
### **Resolves #5**